### PR TITLE
Add Vercel configuration to ignore TypeScript errors during build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,12 @@
 {
   "buildCommand": "next build",
-  "ignoreCommand": "echo 'Ignoring build errors'",
   "devCommand": "next dev -H 0.0.0.0",
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@vercel/next",
-      "config": {
-        "skipBuildCommand": false,
-        "typeCheckingMode": "off",
-        "installCommand": "npm install"
-      }
-    }
-  ]
+  "framework": "nextjs",
+  "installCommand": "npm install",
+  "typescript": {
+    "ignoreBuildErrors": true
+  },
+  "eslint": {
+    "ignoreDuringBuilds": true
+  }
 }


### PR DESCRIPTION
his PR adds configuration to allow building the project on Vercel even with TypeScript errors.

Changes include:
- Added vercel.json configuration file with settings to ignore TypeScript and ESLint errors
- Updated next.config.mjs to ignore TypeScript and ESLint errors during build
- Added BUILD.md with documentation on building with errors

These changes will help with deploying the project for testing purposes.