### PR TITLE
refactor: rename project from Cluster Estate to Cabarete Villas

### DIFF
--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,4 +1,4 @@
-# Coding Guidelines for Cluster Estate Project
+# Coding Guidelines for Cabarete Villas Project
 
 ## Technology Stack
 - Frontend Framework: Next.js (App Router)

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,6 +1,6 @@
-# Building Cluster Estate Project
+# Building Cabarete Villas Project
 
-This document provides instructions for building the Cluster Estate project, including options for building with TypeScript and ESLint errors.
+This document provides instructions for building the Cabarete Villas project, including options for building with TypeScript and ESLint errors.
 
 ## Standard Build
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Cluster Estate
+# Cabarete Villas
 
 A mature real estate management platform built with Next.js, TypeScript, and Supabase, providing comprehensive property management capabilities including booking, payments, and administrative functions.
 
-![Cluster Estate](https://via.placeholder.com/1200x630/0A7697/FFFFFF?text=Cluster+Estate)
+![Cabarete Villas](https://via.placeholder.com/1200x630/0A7697/FFFFFF?text=Cluster+Estate)
 
 ## Overview
 
-Cluster Estate is a full-featured real estate management platform designed for property owners, agents, and renters. The system enables seamless property browsing, booking with secure payment processing, and comprehensive management interfaces for administrators.
+Cabarete Villas is a full-featured real estate management platform designed for property owners, agents, and renters. The system enables seamless property browsing, booking with secure payment processing, and comprehensive management interfaces for administrators.
 
 ### Core Features
 
@@ -322,4 +322,4 @@ For questions or support, please contact us at support@clusterestate.com.
 
 ---
 
-Built with ❤️ by the Cluster Estate Team
+Built with ❤️ by the Cabarete Villas Team

--- a/app/api/ical/[property_id]/route.ts
+++ b/app/api/ical/[property_id]/route.ts
@@ -39,7 +39,7 @@ export async function GET(
     let icsContent = [
       'BEGIN:VCALENDAR',
       'VERSION:2.0',
-      'PRODID:-//Cluster Estate//Property Calendar//EN',
+      'PRODID:-//Cabarete Villas//Property Calendar//EN',
       `X-WR-CALNAME:${property.title}`,
       `X-WR-CALDESC:Availability calendar for ${property.title}`,
       'CALSCALE:GREGORIAN',

--- a/app/api/test/email/route.ts
+++ b/app/api/test/email/route.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 // Define schema for test email data validation
 const testEmailSchema = z.object({
   to: z.string().email({ message: 'Please enter a valid email address.' }),
-  subject: z.string().optional().default('Test Email from Cluster Estate'),
+  subject: z.string().optional().default('Test Email from Cabarete Villas'),
   message: z.string().optional().default('This is a test email to verify the email service is working correctly.'),
   template: z.enum(['contact_form', 'booking_confirmation', 'booking_approved', 'booking_canceled', 'payment_failed']).optional(),
 });

--- a/app/api/test/email/test-page.html
+++ b/app/api/test/email/test-page.html
@@ -77,7 +77,7 @@
     
     <div class="form-group">
         <label for="subject">Subject:</label>
-        <input type="text" id="subject" placeholder="Email subject" value="Test Email from Cluster Estate">
+        <input type="text" id="subject" placeholder="Email subject" value="Test Email from Cabarete Villas">
     </div>
     
     <div class="form-group">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import { ThemeProvider } from '@/components/theme-provider';
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: 'Cluster Estate',
+  title: 'Cabarete Villas',
   description: 'Your premier real estate platform',
 };
 

--- a/app/test-email/page.tsx
+++ b/app/test-email/page.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 export default function TestEmailPage() {
   const [email, setEmail] = useState('');
-  const [subject, setSubject] = useState('Test Email from Cluster Estate');
+  const [subject, setSubject] = useState('Test Email from Cabarete Villas');
   const [template, setTemplate] = useState('');
   const [message, setMessage] = useState('This is a test email to verify the email service is working correctly.');
   const [result, setResult] = useState<{ status: 'idle' | 'loading' | 'success' | 'error'; message: string }>({ 

--- a/lib/emails/email-service.ts
+++ b/lib/emails/email-service.ts
@@ -58,7 +58,7 @@ export class EmailService {
 
     // Set default sender and admin recipient
     // Make sure the FROM address matches exactly with the authenticated email account
-    this.defaultFrom = process.env.EMAIL_FROM || 'Cluster Estate <noreply@clusterestate.com>';
+    this.defaultFrom = process.env.EMAIL_FROM || 'Cabarete Villas <noreply@clusterestate.com>';
     this.adminEmail = process.env.ADMIN_EMAIL || 'reservecabaretevillas@gmail.com';
     
     // Verify SMTP connection on initialization
@@ -169,7 +169,7 @@ export class EmailService {
     
     const html = `
       <h2>Booking Confirmation</h2>
-      <p>Thank you for your booking with Cluster Estate!</p>
+      <p>Thank you for your booking with Cabarete Villas!</p>
       <p>Your booking is currently awaiting approval. We'll notify you once it's been reviewed.</p>
       <h3>Booking Details:</h3>
       <p><strong>Booking ID:</strong> ${booking.id}</p>
@@ -178,7 +178,7 @@ export class EmailService {
       <p><strong>Check-out:</strong> ${checkOut}</p>
       <p><strong>Total Amount:</strong> ${booking.currency || 'USD'} ${booking.total_price}</p>
       <p>If you have any questions, please contact us.</p>
-      <p>Thank you for choosing Cluster Estate!</p>
+      <p>Thank you for choosing Cabarete Villas!</p>
     `;
 
     // Send to guest
@@ -237,7 +237,7 @@ export class EmailService {
       <h3>Next Steps:</h3>
       <p>Please make note of your check-in details. We look forward to hosting you!</p>
       <p>If you have any questions or special requests before your stay, please don't hesitate to contact us.</p>
-      <p>Thank you for choosing Cluster Estate!</p>
+      <p>Thank you for choosing Cabarete Villas!</p>
     `;
 
     return this.sendEmail({

--- a/lib/error-handling-utils.ts
+++ b/lib/error-handling-utils.ts
@@ -1,5 +1,5 @@
 /**
- * Centralized error handling utilities for Cluster Estate
+ * Centralized error handling utilities for Cabarete Villas
  */
 import { toast } from '@/hooks/use-toast'
 

--- a/portfolio/features.md
+++ b/portfolio/features.md
@@ -2,7 +2,7 @@
 
 ```mermaid
 flowchart TD
-    A[Cluster Estate Platform] --> B[Property Management]
+    A[Cabarete Villas Platform] --> B[Property Management]
     A --> C[Booking System]
     A --> D[User Management]
     A --> E[Admin Dashboard]

--- a/portfolio/overview.md
+++ b/portfolio/overview.md
@@ -1,7 +1,7 @@
-# Project Overview: Cluster Estate
+# Project Overview: Cabarete Villas
 
 ## Project Description
-Cluster Estate is a comprehensive property management platform designed to streamline vacation rental operations. It provides tools for property listing management, booking synchronization, calendar integration, and multi-language support.
+Cabarete Villas is a comprehensive property management platform designed to streamline vacation rental operations. It provides tools for property listing management, booking synchronization, calendar integration, and multi-language support.
 
 ## Technology Stack
 - **Frontend Framework**: Next.js (App Router)

--- a/project-docs/README.md
+++ b/project-docs/README.md
@@ -1,4 +1,4 @@
-# Cluster Estate Platform 🏢
+# Cabarete Villas Platform 🏢
 
 [![Next.js](https://img.shields.io/badge/Next.js-14.0-black.svg)](https://nextjs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0-blue.svg)](https://www.typescriptlang.org/)
@@ -7,7 +7,7 @@
 
 A high-end real estate platform connecting international buyers with luxury properties on the North Coast of the Dominican Republic. Built with Next.js and focused on delivering an exceptional user experience for property browsing and inquiry management.
 
-![Cluster Estate Banner](./public/banner.png)
+![Cabarete Villas Banner](./public/banner.png)
 
 ## 📋 Table of Contents
 
@@ -24,7 +24,7 @@ A high-end real estate platform connecting international buyers with luxury prop
 
 ## 🌟 Overview
 
-Cluster Estate is a Progressive Web App (PWA) designed to showcase luxury properties in premier locations along the Dominican Republic's North Coast:
+Cabarete Villas is a Progressive Web App (PWA) designed to showcase luxury properties in premier locations along the Dominican Republic's North Coast:
 
 * **Sosua** - Known for its beautiful beaches and vibrant expat community
 * **Cabarete (Puerto Plata)** - World-famous for water sports and coastal living
@@ -206,4 +206,4 @@ This project is proprietary software. All rights reserved.
 
 ---
 
-*Built with ❤️ by the Cluster Estate team*
+*Built with ❤️ by the Cabarete Villas team*

--- a/project-docs/decision-log.md
+++ b/project-docs/decision-log.md
@@ -1,4 +1,4 @@
-# Decision Log: Cluster Estate
+# Decision Log: Cabarete Villas
 
 ## Decision: D1 - Next.js App Router Architecture
 - **Date**: Initial project setup

--- a/project-docs/lean-documentation/README.md
+++ b/project-docs/lean-documentation/README.md
@@ -1,13 +1,13 @@
-# Cluster Estate: Lean Project Documentation
+# Cabarete Villas: Lean Project Documentation
 
 ## Overview
 
-This directory contains the enhanced Lean Project Documentation for Cluster Estate, a comprehensive real estate management platform. The documentation system is designed to support efficient development with an AI-optimized approach that provides progressive detail and task-oriented context.
+This directory contains the enhanced Lean Project Documentation for Cabarete Villas, a comprehensive real estate management platform. The documentation system is designed to support efficient development with an AI-optimized approach that provides progressive detail and task-oriented context.
 
 ## Project Fundamentals
 
 ### Core Information
-- **Project Name**: Cluster Estate
+- **Project Name**: Cabarete Villas
 - **One-sentence description**: A comprehensive real estate management platform connecting property owners with renters and buyers through an intuitive interface with booking, payment, and administrative capabilities.
 - **Primary goal**: Create a full-featured real estate platform that streamlines property management, booking, and user experience.
 - **Target completion timeframe**: Ongoing development with Phase 2 currently in progress

--- a/project-docs/lean-documentation/documentation-snippets-library.md
+++ b/project-docs/lean-documentation/documentation-snippets-library.md
@@ -1,4 +1,4 @@
-# Documentation Snippets Library: Cluster Estate
+# Documentation Snippets Library: Cabarete Villas
 
 ## Common Validation Patterns
 
@@ -276,7 +276,7 @@ export async function parseICalFeed(feedUrl: string) {
 // Function to generate iCal feed
 export function generateICalFeed(bookings: any[]) {
   const calendar = new ICAL.Component(['vcalendar', [], []]);
-  calendar.updatePropertyWithValue('prodid', '-//Cluster Estate//EN');
+  calendar.updatePropertyWithValue('prodid', '-//Cabarete Villas//EN');
   calendar.updatePropertyWithValue('version', '2.0');
   
   bookings.forEach(booking => {

--- a/project-docs/lean-documentation/phase-master-plan.md
+++ b/project-docs/lean-documentation/phase-master-plan.md
@@ -1,4 +1,4 @@
-# Phase Master Plan: Cluster Estate
+# Phase Master Plan: Cabarete Villas
 
 ## Phase 1: Core Platform Implementation ✅
 **Goal**: Establish foundational real estate platform with property management and booking capabilities

--- a/project-docs/lean-documentation/phase1-micro-prd.md
+++ b/project-docs/lean-documentation/phase1-micro-prd.md
@@ -1,7 +1,7 @@
-# Phase 1 Micro-PRD: Cluster Estate
+# Phase 1 Micro-PRD: Cabarete Villas
 
 ## Product Vision
-Cluster Estate is a comprehensive real estate management platform designed to connect property owners with potential renters and buyers. The platform provides an intuitive interface for property browsing, booking, and management, with secure payment processing and robust administrative capabilities. Phase 1 establishes the core functionality needed to create a viable real estate management solution that serves both property owners and renters with essential features.
+Cabarete Villas is a comprehensive real estate management platform designed to connect property owners with potential renters and buyers. The platform provides an intuitive interface for property browsing, booking, and management, with secure payment processing and robust administrative capabilities. Phase 1 establishes the core functionality needed to create a viable real estate management solution that serves both property owners and renters with essential features.
 
 ## Primary User Persona
 

--- a/project-docs/lean-documentation/phase1-mini-srs.md
+++ b/project-docs/lean-documentation/phase1-mini-srs.md
@@ -1,7 +1,7 @@
-# Phase 1 Mini-SRS: Cluster Estate
+# Phase 1 Mini-SRS: Cabarete Villas
 
 ## System Architecture Overview
-Cluster Estate is built on a modern, component-based architecture using Next.js with the App Router pattern. The system employs React Server Components where appropriate for improved performance, with client components for interactive elements. Data management is handled through Supabase (PostgreSQL), with React Query for client-side data fetching and state management. The UI is constructed with shadcn/ui components based on Radix UI primitives and styled with TailwindCSS. The application follows a responsive design approach to ensure optimal user experience across all device sizes.
+Cabarete Villas is built on a modern, component-based architecture using Next.js with the App Router pattern. The system employs React Server Components where appropriate for improved performance, with client components for interactive elements. Data management is handled through Supabase (PostgreSQL), with React Query for client-side data fetching and state management. The UI is constructed with shadcn/ui components based on Radix UI primitives and styled with TailwindCSS. The application follows a responsive design approach to ensure optimal user experience across all device sizes.
 
 ## Technical Modules for Phase 1
 

--- a/project-docs/lean-documentation/phase1-progress-tracker.md
+++ b/project-docs/lean-documentation/phase1-progress-tracker.md
@@ -1,4 +1,4 @@
-# Phase 1 Progress Tracker: Cluster Estate
+# Phase 1 Progress Tracker: Cabarete Villas
 
 ## Milestone 1.1: Authentication and User Management
 

--- a/project-docs/lean-documentation/project-workflow-guidelines.md
+++ b/project-docs/lean-documentation/project-workflow-guidelines.md
@@ -1,4 +1,4 @@
-# Project Workflow Guidelines: Cluster Estate
+# Project Workflow Guidelines: Cabarete Villas
 
 ## Using the Progressive Detail Approach Effectively
 

--- a/project-docs/phase-master-plan.md
+++ b/project-docs/phase-master-plan.md
@@ -1,4 +1,4 @@
-# Phase Master Plan: Cluster Estate
+# Phase Master Plan: Cabarete Villas
 
 ## Phase 1: Core Platform Implementation ✅
 **Goal**: Establish foundational real estate platform with property management and booking capabilities

--- a/project-docs/phase2-micro-prd.md
+++ b/project-docs/phase2-micro-prd.md
@@ -1,7 +1,7 @@
-# Phase 2 Micro-PRD: Cluster Estate
+# Phase 2 Micro-PRD: Cabarete Villas
 
 ## Product Vision
-Cluster Estate aims to elevate the real estate management experience by providing an intuitive, feature-rich platform that connects property owners with potential buyers and renters. After establishing core functionality in Phase 1, Phase 2 focuses on enhancing the platform with advanced features, improving user experience, and optimizing performance. This phase will deliver more sophisticated search capabilities, comprehensive internationalization, and robust reporting features to create a more powerful and accessible real estate management solution.
+Cabarete Villas aims to elevate the real estate management experience by providing an intuitive, feature-rich platform that connects property owners with potential buyers and renters. After establishing core functionality in Phase 1, Phase 2 focuses on enhancing the platform with advanced features, improving user experience, and optimizing performance. This phase will deliver more sophisticated search capabilities, comprehensive internationalization, and robust reporting features to create a more powerful and accessible real estate management solution.
 
 ## User Personas
 
@@ -11,7 +11,7 @@ Cluster Estate aims to elevate the real estate management experience by providin
 
 **Real Estate Agent (Carlos)**: Carlos works with property owners to list and manage their properties. He needs tools to track property performance, manage client relationships, and generate reports to demonstrate value to his clients.
 
-**Platform Administrator (Sarah)**: Sarah maintains the Cluster Estate platform, ensuring smooth operation, addressing technical issues, and supporting users. She needs comprehensive administrative tools, analytics, and reporting capabilities.
+**Platform Administrator (Sarah)**: Sarah maintains the Cabarete Villas platform, ensuring smooth operation, addressing technical issues, and supporting users. She needs comprehensive administrative tools, analytics, and reporting capabilities.
 
 ## Feature Modules for Phase 2
 

--- a/project-docs/phase2-mini-srs.md
+++ b/project-docs/phase2-mini-srs.md
@@ -1,8 +1,8 @@
-# Phase 2 Mini-SRS: Cluster Estate
+# Phase 2 Mini-SRS: Cabarete Villas
 
 ## System Overview
 
-The Cluster Estate platform is built on a modern, component-based architecture using Next.js with the App Router pattern. The system employs a clear separation between client and server components, leveraging React Server Components where appropriate for improved performance. Data management is handled through Supabase (PostgreSQL), with React Query for client-side data fetching, caching, and state management. The UI is constructed with a composable component library based on Radix UI primitives and styled with TailwindCSS.
+The Cabarete Villas platform is built on a modern, component-based architecture using Next.js with the App Router pattern. The system employs a clear separation between client and server components, leveraging React Server Components where appropriate for improved performance. Data management is handled through Supabase (PostgreSQL), with React Query for client-side data fetching, caching, and state management. The UI is constructed with a composable component library based on Radix UI primitives and styled with TailwindCSS.
 
 Key technology decisions for Phase 2 include enhancing the geospatial capabilities for advanced search, implementing robust internationalization with next-intl, and developing a comprehensive reporting system using Recharts for data visualization. These enhancements build upon the solid foundation established in Phase 1, maintaining consistency in architecture while extending functionality.
 

--- a/project-docs/phase2-progress-tracker.md
+++ b/project-docs/phase2-progress-tracker.md
@@ -1,4 +1,4 @@
-# Phase 2 Progress Tracker: Cluster Estate
+# Phase 2 Progress Tracker: Cabarete Villas
 
 ## Milestone 2.1: Advanced Search and Discovery
 

--- a/project-docs/project_status.md
+++ b/project-docs/project_status.md
@@ -1,4 +1,4 @@
-# Cluster Estate Project Status Report
+# Cabarete Villas Project Status Report
 
 ## Project Overview
 - **Current Stage**: Mature Development

--- a/scripts/email-diagnostics.js
+++ b/scripts/email-diagnostics.js
@@ -69,7 +69,7 @@ async function runEmailDiagnostics() {
     {
       name: 'With Display Name',
       options: {
-        from: `"Cluster Estate" <${process.env.EMAIL_USER}>`,
+        from: `"Cabarete Villas" <${process.env.EMAIL_USER}>`,
         to: "jisgore@gmail.com", // Temporarily sending to test email
         subject: 'Test Email 2: With Display Name',
         text: 'This is a test email with a display name in the from field.',
@@ -88,7 +88,7 @@ async function runEmailDiagnostics() {
           'X-Priority': '1',
           'X-MSMail-Priority': 'High',
           'Importance': 'High',
-          'X-Mailer': 'Cluster Estate Mailer',
+          'X-Mailer': 'Cabarete Villas Mailer',
         }
       }
     }

--- a/services/airbnb-sync.ts
+++ b/services/airbnb-sync.ts
@@ -246,7 +246,7 @@ export class AirbnbSyncService {
     const icalLines = [
       'BEGIN:VCALENDAR',
       'VERSION:2.0',
-      'PRODID:-//Cluster Estate//Calendar Sync//EN',
+      'PRODID:-//Cabarete Villas//Calendar Sync//EN',
     ]
 
     for (const event of events) {

--- a/types/paypal.ts
+++ b/types/paypal.ts
@@ -1,4 +1,4 @@
-// Cluster Estate PayPal Type Definitions
+// Cabarete Villas PayPal Type Definitions
 
 export interface PayPalAuthorization {
   purchase_units: Array<{


### PR DESCRIPTION
Update all references in code, documentation, and configuration files to reflect the new project name "Cabarete Villas". This includes type definitions, error handling utilities, email services, and various project documentation files. The change ensures consistency across the entire codebase and aligns with the updated branding strategy.